### PR TITLE
Fixed timezone issue

### DIFF
--- a/src/main/java/nl/pvanassen/bplist/parser/BPListDate.java
+++ b/src/main/java/nl/pvanassen/bplist/parser/BPListDate.java
@@ -4,7 +4,7 @@ import java.util.*;
 
 class BPListDate implements BPListElement<Date> {
     /** Time interval based dates are measured in seconds from 2001-01-01. */
-    private final static long TIMER_INTERVAL_TIMEBASE = new GregorianCalendar(2001, 0, 1, 1, 0, 0).getTimeInMillis();
+    private final static long TIMER_INTERVAL_TIMEBASE = getTimeInterval();
 
     private final Date value;
 
@@ -24,5 +24,11 @@ class BPListDate implements BPListElement<Date> {
     @Override
     public Date getValue() {
         return value;
+    }
+
+    private static long getTimeInterval() {
+        GregorianCalendar gc = new GregorianCalendar(TimeZone.getTimeZone("UTC"));
+        gc.set(2001, Calendar.JANUARY, 1, 0, 0, 0);
+        return gc.getTimeInMillis();
     }
 }


### PR DESCRIPTION
Hello!
I am try to use you library, but in my time zone (UTC+03) testITunesSmall failed. I fix code, and now test passes in any timezone. 

I am set time zone to calendar, what compute TIMER_INTERVAL_TIMEBASE, and change start time period from Jan 1 2001 00:01:00 GMT to Jan 1 2001 00:00:00 GMT ([link](https://developer.apple.com/library/prerelease/mac/documentation/CoreFoundation/Reference/CFDateRef/index.html#//apple_ref/c/func/CFDateGetAbsoluteTime)). I am think it works for you, because you live in UTC+01.

I am sorry for my English.

If I make something wrong, please write, I try to fix that.
